### PR TITLE
If there is no response, there is no response...

### DIFF
--- a/src/Carriers/Transsmart.php
+++ b/src/Carriers/Transsmart.php
@@ -134,7 +134,7 @@ class Transsmart
                 $this->logger->setResponseCode(null);
                 $this->logger->setResponseData('Transsmart error (no message provided)');
 
-                throw new TranssmartException('Transsmart error (no message provided): ' . $e->getResponse()->getBody()->getContents());
+                throw new TranssmartException('Transsmart error (no message provided)');
             }
         }
 


### PR DESCRIPTION
According to bugsnag error 5898a677a8a90c07fd6a6146, `getResponse()` returns null if `hasResponse()` is false. Which also sounds logical.