### PR TITLE
Use exception message instead of (non-existing) response object

### DIFF
--- a/src/TranssmartClient.php
+++ b/src/TranssmartClient.php
@@ -90,13 +90,12 @@ class TranssmartClient
                 $this->logger->setResponseData($error);
 
                 throw new TranssmartException($error);
-            } else {
-                $this->logger->setResponseCode(null);
-                $this->logger->setResponseData('Transsmart error (no message provided)');
-
-                throw new TranssmartException('Transsmart error (no message provided): ' . $e->getResponse()->getBody()->getContents());
             }
 
+            $this->logger->setResponseCode(null);
+            $this->logger->setResponseData('Transsmart error (no message provided)');
+
+            throw new TranssmartException('Transsmart error (no message provided): ' . $e->getMessage());
         }
 
         return json_decode($contents, true);


### PR DESCRIPTION
Wanneer er een storing is bij Transsmart wordt geen response teruggestuurd, deze exception flow ging er vanuit dat die wel beschikbaar was.

De oplossing is gebruik te maken van de exception message in plaats van de response body.